### PR TITLE
Fix for error when hide is called before render

### DIFF
--- a/src/coffee/ux/callout/Callout.coffee
+++ b/src/coffee/ux/callout/Callout.coffee
@@ -134,7 +134,8 @@ Ext.define( 'Ext.ux.callout.Callout',
 	###
 	hide: ->
 		@clearTimers()
-		@getEl().removeAnchor()
+		if @rendered
+			@getEl().removeAnchor()
 		return @callParent( arguments )
 	
 	###*


### PR DESCRIPTION
Quick fix to check that the component has been rendered before calling removeAnchor. Otherwise, getEl would return nothing and cause a JavaScript error.
